### PR TITLE
rename rclient clean target name to match plcontainer clean clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.so
 /bin/client
 /bin/*.so
+*.o

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ common_objs = $(foreach src,$(common_src),$(subst .c,.o,$(src)))
 shared_src = rcall.c rconversions.c rlogging.c
 
 .PHONY: default
-default: clean all
+default: clean-clients all
 
 .PHONY: clean_common
 clean_common:
@@ -63,7 +63,7 @@ debug: client
 all: CUSTOMFLAGS = -O3
 all: client
 
-clean: clean_common
+clean-clients: clean_common
 	rm -f *.o
 	rm -f client
 	rm -f bin/client


### PR DESCRIPTION
Currently plcontainer 'make clean' cannot clean clients objects, so I will add a target "clean-clients" in plcontainer/Makefile to call clients clean. plcontainer/Makefile call the pgxs 'clean', so I want to rename the target name 'clean' in clients makefile to avoid infinite recursive call.