### PR TITLE
Handle NA_STRING specially.

### DIFF
--- a/rconversions.c
+++ b/rconversions.c
@@ -467,7 +467,11 @@ static int plc_r_object_as_float8(SEXP input, char **output, plcRType *type UNUS
 static int plc_r_object_as_text(SEXP input, char **output, plcRType *type UNUSED) {
 	int res = 0;
 
-	*output = strdup(CHAR(asChar(input)));
+	if (asChar(input) == NA_STRING)
+		*output = strdup("");
+	else
+		*output = strdup(CHAR(asChar(input)));
+
 	return res;
 }
 


### PR DESCRIPTION
```
To reproduce:

create or replace function plc_null_r() returns text as $$
 # container: plc_r_shared
return (system('ifconfig >/dev/null', intern = TRUE));
$$ language 'plcontainer';

postgres=# select plc_null_r();
 plc_null_r
 ------------
  NA
  (1 row)

"NA" is really not a good output.  With this fix, the output now looks like this:

postgres=# select plc_null_r();
 plc_null_r
 ------------

 (1 row)
  ```