### PR TITLE
Fix matrix processing issue when converting to array/setof

### DIFF
--- a/rconversions.h
+++ b/rconversions.h
@@ -26,6 +26,11 @@ typedef int (*plcROutputFunc)(SEXP, char **, plcRType *);
 typedef struct plcRArrPointer {
 	size_t pos;
 	SEXP obj;
+	/* Used for martix to array */
+	size_t nc;
+	size_t nr;
+	size_t px;
+	size_t py;
 } plcRArrPointer;
 
 typedef struct plcRArrMeta {
@@ -78,8 +83,6 @@ void plc_free_result_conversions(plcRResult *res);
 SEXP get_r_vector(plcDatatype type_id, int numels);
 
 rawdata *plc_r_vector_element_rawdata(SEXP vector, int idx, plcRType *type);
-
-int plc_r_matrix_as_setof(SEXP input, int start, int dim1, char **output, plcRType *type);
 
 plcROutputFunc plc_get_output_function(plcDatatype dt);
 


### PR DESCRIPTION
If the R script returns a matrix and needs to convert to
array/setof as results, PL/Container will produce incorrect
results during convert phase. This is cause by the R martix
has different structure comparing with R array.

In this patch, the convertion phase for R matrix has been fixed by
correct selecting element from R matrix. The redundant codes also
has been cleared.