### PR TITLE
Refactor header reference in all *.c and *.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,7 @@ else
 
 # Global build Directories
 
-SERVER_INCLUDE_DIR = ../include/server
-COMMON_INCLUDE_DIR = ../include/common
+INCLUDE_DIR = ../include
 
 
 # R build flags
@@ -43,11 +42,11 @@ COMMON_INCLUDE_DIR = ../include/common
 CLIENT_CFLAGS = $(r_includespec)
 CLIENT_LDFLAGS = -Wl,--export-dynamic -fopenmp -Wl,-z,relro -L${r_libdir2x} -lR -Wl,-rpath,'$$ORIGIN'
 
-override CFLAGS += -std=gnu99 $(CLIENT_CFLAGS) -I$(SERVER_INCLUDE_DIR) -I$(COMMON_INCLUDE_DIR)/ -DPLC_CLIENT -Wall -Wextra -Werror -Wno-unused-result
+override CFLAGS += -std=gnu99 $(CLIENT_CFLAGS) -I$(INCLUDE_DIR) -DPLC_SERVER -Wall -Wextra -Werror -Wno-unused-result
 override LDFLAGS += $(CLIENT_LDFLAGS)
 
 CLIENT = rclient
-common_src = ../common/comm_channel.c ../common/comm_connectivity.c ../common/comm_messages.c \
+common_src = ../common/base_network.c ../common/comm_channel.c ../common/comm_connectivity.c ../common/comm_messages.c ../common/comm_dummy_server.c \
              ../server/server.c ../server/misc.c
 common_objs = $(foreach src,$(common_src),$(subst .c,.$(CLIENT).o,$(src)))
 shared_src = rcall.c rconversions.c rlogging.c

--- a/client.c
+++ b/client.c
@@ -7,9 +7,9 @@
 #include <stdlib.h>
 #include <assert.h>
 
-#include "comm_connectivity.h"
-#include "server.h"
-#include "misc.h"
+#include "common/comm_dummy.h"
+#include "common/comm_connectivity.h"
+#include "server/server.h"
 #include "rcall.h"
 
 int main(int argc UNUSED, char **argv UNUSED) {

--- a/rcall.c
+++ b/rcall.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <netinet/ip.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -24,10 +25,11 @@
 #include <Rdefines.h>
 
 /* PL/Container header files */
-#include "comm_channel.h"
-#include "messages/messages.h"
-#include "comm_connectivity.h"
-#include "misc.h"
+#include "common/comm_channel.h"
+#include "common/comm_connectivity.h"
+#include "common/comm_dummy.h"
+#include "common/messages/messages.h"
+#include "server/server.h"
 #include "rcall.h"
 #include "rconversions.h"
 #include "rlogging.h"

--- a/rcall.h
+++ b/rcall.h
@@ -7,8 +7,8 @@
 #ifndef PLC_RCALL_H
 #define PLC_RCALL_H
 
-#include "messages/messages.h"
-#include "comm_connectivity.h"
+#include "common/comm_connectivity.h"
+#include "common/messages/messages.h"
 
 #define UNUSED __attribute__ (( unused ))
 

--- a/rconversions.c
+++ b/rconversions.c
@@ -4,9 +4,12 @@
  *
  *------------------------------------------------------------------------------
  */
+#include <stdbool.h>
+#include <stddef.h>
 #include "rconversions.h"
 #include "rcall.h"
-#include "comm_channel.h"
+#include "common/comm_channel.h"
+#include "common/comm_dummy.h"
 
 static SEXP plc_r_object_from_int1(char *input, plcRType *type);
 

--- a/rconversions.h
+++ b/rconversions.h
@@ -12,8 +12,7 @@
 #include <Rinternals.h>
 #include <Rdefines.h>
 
-#include "messages/messages.h"
-#include "misc.h"
+#include "common/messages/messages.h"
 
 #define PLC_MAX_ARRAY_DIMS 2
 

--- a/rlogging.c
+++ b/rlogging.c
@@ -7,8 +7,9 @@
 #include <R.h>
 #include <Rinternals.h>
 
-#include "messages/messages.h"
-#include "comm_channel.h"
+#include "common/comm_channel.h"
+#include "common/comm_dummy.h"
+#include "common/messages/messages.h"
 #include "rcall.h"
 #include "rlogging.h"
 

--- a/rlogging.h
+++ b/rlogging.h
@@ -9,8 +9,6 @@
 
 #include <R.h>
 
-#include "misc.h"
-
 SEXP plr_debug(SEXP args);
 
 SEXP plr_log(SEXP args);


### PR DESCRIPTION
All header files in plcontainers are arranged to 3 folders:
1. common - contains all common code API, with the same
            or different implementations. And any header in the folder
            must not contain any header in `plc` or `server`
2. plc    - contains all GPDB side headers, which must not be
            included by `common` or `server`
3. server - contains all GPDB side headers, which must not be
            included by `common` or `plc`

See the PR in plcontainer:
  https://github.com/greenplum-db/plcontainer/pull/501