### PR TITLE
Support Setof as argument and return value in R server

### DIFF
--- a/include/rtypeconverter.hh
+++ b/include/rtypeconverter.hh
@@ -24,6 +24,7 @@ class ConvertToSEXP {
     SEXP byteaToSEXP(const std::string &v);
     SEXP compositeToSEXP(const plcontainer::CompositeData &v);
     SEXP arrayToSEXP(const plcontainer::ArrayData &v);
+    SEXP setofToSEXP(const plcontainer::SetOfData &v);
 
     void setLogger(RServerLog *log) { this->rLog = log; }
 
@@ -41,6 +42,9 @@ class ConvertToProtoBuf {
     void compositeToProtoBuf(SEXP v, std::vector<plcontainer::PlcDataType> &subTypes,
                              plcontainer::CompositeData *result);
     void arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type, plcontainer::ArrayData *result);
+    void setofToProtoBuf(SEXP v, std::vector<plcontainer::PlcDataType> &subTypes,
+                         plcontainer::SetOfData *result);
+
     void setLogger(RServerLog *log) { this->rLog = log; }
 
    private:
@@ -50,6 +54,16 @@ class ConvertToProtoBuf {
     double realToProtoBuf(SEXP v);
     std::string textToProtoBuf(SEXP v);
     std::string byteaToProtoBuf(SEXP v);
+    void dataframeToSetof(SEXP frame, std::vector<plcontainer::PlcDataType> &subTypes,
+                          plcontainer::SetOfData *result);
+    void dataframeColumnStoreToRowStore(SEXP column, int32_t rowlength, int columnId,
+                                        plcontainer::SetOfData *result,
+                                        plcontainer::PlcDataType cType);
+    void dataframeColumnStoreToRowStoreFastPath(SEXP column, int32_t rowlength, int columnId,
+                                                plcontainer::SetOfData *result,
+                                                plcontainer::PlcDataType cType);
+    void matrixToSetof(SEXP frame, std::vector<plcontainer::PlcDataType> &subTypes,
+                       plcontainer::SetOfData *result);
 };
 
 #endif  // PLC_RTYPRCONVERTER_H

--- a/include/rutils.hh
+++ b/include/rutils.hh
@@ -29,6 +29,7 @@ enum class RServerLogLevel {
     LOGS,
     WARNINGS,
     ERRORS,
+    FATALS,
     UNKNOWN = 99,
 };
 
@@ -39,10 +40,10 @@ enum class RServerWorkingMode {
     UNKNOWN = 99,
 };
 
-class RServerErrorException : public std::exception {
+class RServerFatalException : public std::exception {
    public:
-    RServerErrorException() { this->msg = "R Server Runtime Error "; }
-    RServerErrorException(std::string &msg) { this->msg = "R Server Runtime Error " + msg + " "; }
+    RServerFatalException() { this->msg = "R Server Runtime Error "; }
+    RServerFatalException(std::string &msg) { this->msg = "R Server Runtime Error " + msg + " "; }
 
     virtual const char *what() const noexcept override { return this->msg.c_str(); }
 
@@ -50,14 +51,12 @@ class RServerErrorException : public std::exception {
     std::string msg;
 };
 
-class RServerWarningException : public std::exception {
+class RServerErrorException : public std::exception {
    public:
-    RServerWarningException() {
+    RServerErrorException() {
         this->msg = "R Server Runtime Warning ";
     };
-    RServerWarningException(std::string &msg) {
-        this->msg = "R Server Runtime Warning " + msg + " ";
-    }
+    RServerErrorException(std::string &msg) { this->msg = "R Server Runtime Warning " + msg + " "; }
 
     virtual const char *what() const noexcept override { return this->msg.c_str(); }
 

--- a/src/rtypeconverter.cc
+++ b/src/rtypeconverter.cc
@@ -36,8 +36,6 @@ SEXP ConvertToSEXP::byteaToSEXP(const std::string &v) {
     int status;
 
     PROTECT(obj = NEW_RAW(v.size()));
-    this->rLog->log(RServerLogLevel::LOGS, "size of string is %d, string is %s", v.size(),
-                    v.data());
     memcpy((char *)RAW(obj), v.data(), v.size());
 
     /*
@@ -53,7 +51,7 @@ SEXP ConvertToSEXP::byteaToSEXP(const std::string &v) {
     PROTECT(result = R_tryEval(s, R_GlobalEnv, &status));
 
     if (status != 0) {
-        this->rLog->log(RServerLogLevel::WARNINGS, "Could not convert bytea to R object");
+        this->rLog->log(RServerLogLevel::ERRORS, "Could not convert bytea to R object");
     }
 
     UNPROTECT_PTR(obj);
@@ -74,7 +72,7 @@ bool ConvertToProtoBuf::boolToProtoBuf(SEXP v) {
             res = (bool)asReal(v) == 0 ? 0 : 1;
             break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS, "Could not convert R object to bool");
+            this->rLog->log(RServerLogLevel::ERRORS, "Could not convert R object to bool");
             break;
     }
     return res;
@@ -93,7 +91,7 @@ int32_t ConvertToProtoBuf::intToProtoBuf(SEXP v) {
             res = (int32_t)asReal(v);
             break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS, "Could not convert R object to int");
+            this->rLog->log(RServerLogLevel::ERRORS, "Could not convert R object to int");
             break;
     }
     return res;
@@ -112,7 +110,7 @@ double ConvertToProtoBuf::realToProtoBuf(SEXP v) {
             res = asReal(v);
             break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS, "Could not convert R object to real");
+            this->rLog->log(RServerLogLevel::ERRORS, "Could not convert R object to real");
             break;
     }
     return res;
@@ -147,7 +145,7 @@ std::string ConvertToProtoBuf::byteaToProtoBuf(SEXP v) {
     if (status != 0) {
         UNPROTECT_PTR(s);
         UNPROTECT_PTR(obj);
-        this->rLog->log(RServerLogLevel::WARNINGS, "Cannot serialize object");
+        this->rLog->log(RServerLogLevel::ERRORS, "Cannot serialize object");
     }
 
     len = LENGTH(obj);
@@ -230,7 +228,7 @@ SEXP ConvertToSEXP::scalarToSEXP(const plcontainer::ScalarData &v) {
             break;
         }
         default: {
-            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %s",
+            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %s",
                             v.DebugString().c_str());
             PROTECT(result = R_NilValue);
         }
@@ -268,7 +266,7 @@ void ConvertToProtoBuf::scalarToProtobuf(SEXP v, plcontainer::PlcDataType type,
         }
         default:
             result->set_isnull(true);
-            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type from R to GPDB");
+            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type from R to GPDB");
     }
 }
 
@@ -277,7 +275,7 @@ void ConvertToProtoBuf::compositeToProtoBuf(SEXP v, std::vector<plcontainer::Plc
     SEXP dfcol;
 
     if (!isFrame(v)) {
-        this->rLog->log(RServerLogLevel::WARNINGS, "Returned R Object must be Data.Frame");
+        this->rLog->log(RServerLogLevel::ERRORS, "Returned R Object must be Data.Frame");
     }
 
     // Convert each column to a subtype in GPDB UDT based on sub-type
@@ -354,7 +352,7 @@ SEXP ConvertToSEXP::arrayToSEXP(const plcontainer::ArrayData &v) {
             }
         } break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS,
+            this->rLog->log(RServerLogLevel::ERRORS,
                             "Unsupport type in array argument, which is %d", v.elementtype());
             PROTECT(result = R_NilValue);
             break;
@@ -396,7 +394,7 @@ void ConvertToProtoBuf::arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type,
                             element->set_byteavalue(std::to_string(LOGICAL(v)[i]));
                         } break;
                         default:
-                            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d",
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
                                             type);
                             break;
                     }
@@ -426,7 +424,7 @@ void ConvertToProtoBuf::arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type,
                             element->set_byteavalue(std::to_string(INTEGER(v)[i]));
                         } break;
                         default:
-                            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d",
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
                                             type);
                             break;
                     }
@@ -456,7 +454,7 @@ void ConvertToProtoBuf::arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type,
                             element->set_byteavalue(std::to_string(REAL(v)[i]));
                         } break;
                         default:
-                            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d",
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
                                             type);
                             break;
                     }
@@ -478,7 +476,7 @@ void ConvertToProtoBuf::arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type,
                             element->set_byteavalue(std::string(value));
                         } break;
                         default:
-                            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d",
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
                                             type);
                             break;
                     }
@@ -488,7 +486,7 @@ void ConvertToProtoBuf::arrayToProtoBuf(SEXP v, plcontainer::PlcDataType type,
             }
         } break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d", type);
+            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d", type);
             break;
     }
 }
@@ -512,9 +510,638 @@ SEXP ConvertToSEXP::allocRVector(const plcontainer::PlcDataType type, int length
             PROTECT(result = NEW_CHARACTER(length));
             break;
         default:
-            this->rLog->log(RServerLogLevel::WARNINGS, "Unsupport type in value %d", type);
+            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d", type);
             PROTECT(result = R_NilValue);
             break;
     }
     return result;
+}
+
+SEXP ConvertToSEXP::setofToSEXP(const plcontainer::SetOfData &v) {
+    SEXP result = R_NilValue;
+    SEXP cnames = R_NilValue;
+    SEXP rnames = R_NilValue;
+    int columnLen = v.columntypes_size();
+    int32_t rowLen = v.rowvalues_size();
+
+    // init a new list with number of columns
+    PROTECT(result = NEW_LIST(columnLen));
+    // init a new string vector with number of columns
+    PROTECT(cnames = NEW_CHARACTER(columnLen));
+
+    for (int i = 0; i < columnLen; i++) {
+        SEXP columnData = R_NilValue;
+        // Set column name
+        SET_STRING_ELT(cnames, i, mkChar(v.columnnames(i).c_str()));
+
+        // Init a new vector for this column
+        columnData = this->allocRVector(v.columntypes(i), rowLen);
+
+        switch (v.columntypes(i)) {
+            case plcontainer::PlcDataType::LOGICAL: {
+                for (int j = 0; j < rowLen; j++) {
+                    if (!v.rowvalues(j).values(i).isnull()) {
+                        LOGICAL_DATA(columnData)[j] = v.rowvalues(j).values(i).logicalvalue();
+                    } else {
+                        LOGICAL_DATA(columnData)[j] = NA_LOGICAL;
+                    }
+                }
+            } break;
+            case plcontainer::PlcDataType::INT: {
+                for (int j = 0; j < rowLen; j++) {
+                    if (!v.rowvalues(j).values(i).isnull()) {
+                        INTEGER_DATA(columnData)[j] = v.rowvalues(j).values(i).intvalue();
+                    } else {
+                        INTEGER_DATA(columnData)[j] = NA_INTEGER;
+                    }
+                }
+            } break;
+            case plcontainer::PlcDataType::REAL: {
+                for (int j = 0; j < rowLen; j++) {
+                    if (!v.rowvalues(j).values(i).isnull()) {
+                        NUMERIC_DATA(columnData)[j] = v.rowvalues(j).values(i).realvalue();
+                    } else {
+                        NUMERIC_DATA(columnData)[j] = NA_REAL;
+                    }
+                }
+            } break;
+            case plcontainer::PlcDataType::BYTEA: {
+                for (int j = 0; j < rowLen; j++) {
+                    if (!v.rowvalues(j).values(i).isnull()) {
+                        SET_STRING_ELT(
+                            columnData, j,
+                            COPY_TO_USER_STRING(v.rowvalues(j).values(i).byteavalue().data()));
+                    } else {
+                        SET_STRING_ELT(columnData, j, NA_STRING);
+                    }
+                }
+            } break;
+            case plcontainer::PlcDataType::TEXT: {
+                for (int j = 0; j < rowLen; j++) {
+                    if (!v.rowvalues(j).values(i).isnull()) {
+                        SET_STRING_ELT(
+                            columnData, j,
+                            COPY_TO_USER_STRING(v.rowvalues(j).values(i).stringvalue().c_str()));
+                    } else {
+                        SET_STRING_ELT(columnData, j, NA_STRING);
+                    }
+                }
+            } break;
+            default:
+                this->rLog->log(RServerLogLevel::ERRORS,
+                                "Unsupport type in array argument, which is %d", v.columntypes(i));
+                PROTECT(result = R_NilValue);
+                break;
+        }
+
+        SET_VECTOR_ELT(result, i, columnData);
+        UNPROTECT_PTR(columnData);
+    }
+
+    // Attach the column names
+    setAttrib(result, R_NamesSymbol, cnames);
+
+    // attach row names, we use row number here, start from 1, it is optional
+    rnames = this->allocRVector(plcontainer::PlcDataType::TEXT, rowLen);
+    for (int i = 0; i < rowLen; i++) {
+        SET_STRING_ELT(rnames, i, COPY_TO_USER_STRING(std::to_string(i + 1).c_str()));
+    }
+    setAttrib(result, R_RowNamesSymbol, rnames);
+    // The setof is converted as a data.frame structure
+    setAttrib(result, R_ClassSymbol, mkString("data.frame"));
+    UNPROTECT_PTR(cnames);
+    UNPROTECT_PTR(rnames);
+
+    return result;
+}
+
+void ConvertToProtoBuf::dataframeToSetof(SEXP frame,
+                                         std::vector<plcontainer::PlcDataType> &subTypes,
+                                         plcontainer::SetOfData *result) {
+    int32_t rowlength;
+
+    if (Rf_length(frame) != (int)subTypes.size()) {
+        this->rLog->log(RServerLogLevel::ERRORS,
+                        "The number of column in data.frame (%d) does not match the number of "
+                        "column in returned type (%d)",
+                        Rf_length(frame), subTypes.size());
+    }
+
+    // Get the number of rows, List is considered as one row data frame
+    if (isFrame(frame)) {
+        SEXP firstColumn;
+        PROTECT(firstColumn = VECTOR_ELT(frame, 0));
+        rowlength = Rf_length(firstColumn);
+        UNPROTECT_PTR(firstColumn);
+    } else {
+        rowlength = 1;
+    }
+
+    // Init the result first via add_*()
+    for (int32_t r = 0; r < rowlength; r++) {
+        plcontainer::CompositeData *cdata;
+        cdata = result->add_rowvalues();
+        for (int c = 0; c < (int)subTypes.size(); c++) {
+            cdata->add_values();
+        }
+    }
+
+    // extract each column from data.frame
+    for (int i = 0; i < (int)subTypes.size(); i++) {
+        SEXP column;
+
+        PROTECT(column = VECTOR_ELT(frame, i));
+
+        if (isFactor(column)) {
+            SEXP f;
+            PROTECT(f = Rf_asCharacterFactor(column));
+            // We need to convert factor column to string
+            this->dataframeColumnStoreToRowStore(f, rowlength, i, result,
+                                                 plcontainer::PlcDataType::TEXT);
+            UNPROTECT_PTR(f);
+        } else {
+            // Check whether the code can go fast path
+            switch (subTypes[i]) {
+                case plcontainer::PlcDataType::LOGICAL: {
+                    if (IS_LOGICAL(column)) {
+                        this->dataframeColumnStoreToRowStoreFastPath(
+                            column, rowlength, i, result, plcontainer::PlcDataType::LOGICAL);
+                    } else {
+                        // test failure, go normal path
+                        this->dataframeColumnStoreToRowStore(column, rowlength, i, result,
+                                                             subTypes[i]);
+                    }
+                } break;
+                case plcontainer::PlcDataType::INT: {
+                    if (IS_INTEGER(column)) {
+                        this->dataframeColumnStoreToRowStoreFastPath(column, rowlength, i, result,
+                                                                     plcontainer::PlcDataType::INT);
+                    } else {
+                        // test failure, go normal path
+                        this->dataframeColumnStoreToRowStore(column, rowlength, i, result,
+                                                             subTypes[i]);
+                    }
+                } break;
+                case plcontainer::PlcDataType::REAL: {
+                    if (IS_NUMERIC(column) || IS_INTEGER(column)) {
+                        this->dataframeColumnStoreToRowStoreFastPath(
+                            column, rowlength, i, result, plcontainer::PlcDataType::REAL);
+                    } else {
+                        // test failure, go normal path
+                        this->dataframeColumnStoreToRowStore(column, rowlength, i, result,
+                                                             subTypes[i]);
+                    }
+                } break;
+                default:
+                    this->dataframeColumnStoreToRowStore(column, rowlength, i, result, subTypes[i]);
+                    break;
+            }
+        }
+        UNPROTECT_PTR(column);
+    }
+}
+
+void ConvertToProtoBuf::dataframeColumnStoreToRowStoreFastPath(SEXP column, int32_t rowlength,
+                                                               int columnId,
+                                                               plcontainer::SetOfData *result,
+                                                               plcontainer::PlcDataType cType) {
+    switch (cType) {
+        case plcontainer::PlcDataType::LOGICAL: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                if (LOGICAL_DATA(column)[i] != NA_LOGICAL) {
+                    result->mutable_rowvalues(i)->mutable_values(columnId)->set_logicalvalue(
+                        LOGICAL_DATA(column)[i]);
+                } else {
+                    result->mutable_rowvalues(i)->mutable_values(columnId)->set_isnull(true);
+                }
+            }
+        } break;
+        case plcontainer::PlcDataType::INT: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                if (INTEGER_DATA(column)[i] != NA_INTEGER) {
+                    result->mutable_rowvalues(i)->mutable_values(columnId)->set_intvalue(
+                        INTEGER_DATA(column)[i]);
+                } else {
+                    result->mutable_rowvalues(i)->mutable_values(columnId)->set_isnull(true);
+                }
+            }
+        }
+        case plcontainer::PlcDataType::REAL: {
+            if (IS_INTEGER(column)) {
+                for (int32_t i = 0; i < rowlength; i++) {
+                    if (INTEGER_DATA(column)[i] != NA_INTEGER) {
+                        result->mutable_rowvalues(i)->mutable_values(columnId)->set_realvalue(
+                            (double)INTEGER_DATA(column)[i]);
+                    } else {
+                        result->mutable_rowvalues(i)->mutable_values(columnId)->set_isnull(true);
+                    }
+                }
+            } else {
+                for (int32_t i = 0; i < rowlength; i++) {
+                    if (NUMERIC_DATA(column)[i] != NA_REAL) {
+                        result->mutable_rowvalues(i)->mutable_values(columnId)->set_realvalue(
+                            NUMERIC_DATA(column)[i]);
+                    } else {
+                        result->mutable_rowvalues(i)->mutable_values(columnId)->set_isnull(true);
+                    }
+                }
+            }
+        }
+        default:
+            break;
+    }
+}
+
+void ConvertToProtoBuf::dataframeColumnStoreToRowStore(SEXP column, int32_t rowlength, int columnId,
+                                                       plcontainer::SetOfData *result,
+                                                       plcontainer::PlcDataType cType) {
+    switch (TYPEOF(column)) {
+        case LGLSXP: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                plcontainer::ScalarData *element =
+                    result->mutable_rowvalues(i)->mutable_values(columnId);
+                if (LOGICAL(column)[i] != NA_LOGICAL) {
+                    switch (cType) {
+                        case plcontainer::PlcDataType::LOGICAL: {
+                            this->rLog->log(RServerLogLevel::LOGS, "return type is bool");
+                            element->set_logicalvalue(LOGICAL(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::INT: {
+                            this->rLog->log(RServerLogLevel::LOGS, "return type is int");
+                            element->set_intvalue((int32_t)LOGICAL(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::REAL: {
+                            element->set_realvalue((double)LOGICAL(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::TEXT: {
+                            element->set_stringvalue(std::to_string(LOGICAL(column)[i]));
+                        } break;
+                        case plcontainer::PlcDataType::BYTEA: {
+                            element->set_byteavalue(std::to_string(LOGICAL(column)[i]));
+                        } break;
+                        default:
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                            cType);
+                            break;
+                    }
+                } else {
+                    element->set_isnull(true);
+                }
+            }
+        } break;
+        case INTSXP: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                plcontainer::ScalarData *element =
+                    result->mutable_rowvalues(i)->mutable_values(columnId);
+                if (INTEGER(column)[i] != NA_INTEGER) {
+                    switch (cType) {
+                        case plcontainer::PlcDataType::LOGICAL: {
+                            element->set_logicalvalue(INTEGER(column)[i] == 0 ? false : true);
+                        } break;
+                        case plcontainer::PlcDataType::INT: {
+                            element->set_intvalue(INTEGER(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::REAL: {
+                            element->set_realvalue((double)INTEGER(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::TEXT: {
+                            element->set_stringvalue(std::to_string(INTEGER(column)[i]));
+                        } break;
+                        case plcontainer::PlcDataType::BYTEA: {
+                            element->set_byteavalue(std::to_string(INTEGER(column)[i]));
+                        } break;
+                        default:
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                            cType);
+                            break;
+                    }
+                } else {
+                    element->set_isnull(true);
+                }
+            }
+        } break;
+        case REALSXP: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                plcontainer::ScalarData *element =
+                    result->mutable_rowvalues(i)->mutable_values(columnId);
+                if (REAL(column)[i] != NA_REAL) {
+                    switch (cType) {
+                        case plcontainer::PlcDataType::LOGICAL: {
+                            element->set_logicalvalue((bool)REAL(column)[i] == 0 ? 0 : 1);
+                        } break;
+                        case plcontainer::PlcDataType::INT: {
+                            element->set_intvalue((int32_t)REAL(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::REAL: {
+                            element->set_realvalue(REAL(column)[i]);
+                        } break;
+                        case plcontainer::PlcDataType::TEXT: {
+                            element->set_stringvalue(std::to_string(REAL(column)[i]));
+                        } break;
+                        case plcontainer::PlcDataType::BYTEA: {
+                            element->set_byteavalue(std::to_string(REAL(column)[i]));
+                        } break;
+                        default:
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                            cType);
+                            break;
+                    }
+                } else {
+                    element->set_isnull(true);
+                }
+            }
+        } break;
+        case STRSXP: {
+            for (int32_t i = 0; i < rowlength; i++) {
+                const char *value = CHAR(STRING_ELT(column, i));
+                plcontainer::ScalarData *element =
+                    result->mutable_rowvalues(i)->mutable_values(columnId);
+                if (STRING_ELT(column, i) != NA_STRING && value != NULL) {
+                    switch (cType) {
+                        case plcontainer::PlcDataType::TEXT: {
+                            element->set_stringvalue(std::string(value));
+                        } break;
+                        case plcontainer::PlcDataType::BYTEA: {
+                            element->set_byteavalue(std::string(value));
+                        } break;
+                        default:
+                            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                            cType);
+                            break;
+                    }
+                } else {
+                    element->set_isnull(true);
+                }
+            }
+        } break;
+        default:
+            this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d", cType);
+            break;
+    }
+}
+
+void ConvertToProtoBuf::matrixToSetof(SEXP mx, std::vector<plcontainer::PlcDataType> &subTypes,
+                                      plcontainer::SetOfData *result) {
+
+    int columnLength = subTypes.size();
+    int rowLength;
+
+    if (isMatrix(mx)) {
+        // get the n*m details from matrix
+        if (columnLength == ncols(mx)) {
+            rowLength = nrows(mx);
+        } else {
+            this->rLog->log(RServerLogLevel::ERRORS,
+                            "the column length %d of R object is different with column length %d "
+                            "of return type in matrix",
+                            ncols(mx), columnLength);
+        }
+
+    } else {
+        // vector is considered as a one row matrix
+        if (columnLength == Rf_length(mx)) {
+            rowLength = 1;
+        } else {
+            this->rLog->log(RServerLogLevel::ERRORS,
+                            "the column length %d of R object is different with column length %d "
+                            "of return type in vector",
+                            Rf_length(mx), columnLength);
+        }
+    }
+
+    // Init the result first via add_*()
+
+    for (int r = 0; r < rowLength; r++) {
+        plcontainer::CompositeData *cdata;
+        cdata = result->add_rowvalues();
+        for (int c = 0; c < columnLength; c++) {
+            cdata->add_values();
+        }
+    }
+
+    for (int i = 0; i < columnLength; i++) {
+        switch (subTypes[i]) {
+            case plcontainer::PlcDataType::LOGICAL: {
+                switch (TYPEOF(mx)) {
+                    case LGLSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (LOGICAL(mx)[rowLength * i + j] != NA_LOGICAL) {
+                                element->set_logicalvalue(LOGICAL(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case INTSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (INTEGER(mx)[rowLength * i + j] != NA_INTEGER) {
+                                element->set_logicalvalue(
+                                    (bool)INTEGER(mx)[rowLength * i + j] == 0 ? 0 : 1);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case REALSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (REAL(mx)[rowLength * i + j] != NA_REAL) {
+                                element->set_logicalvalue(
+                                    (bool)REAL(mx)[rowLength * i + j] == 0 ? 0 : 1);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    default:
+                        this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                        subTypes[i]);
+                        break;
+                }
+            } break;
+            case plcontainer::PlcDataType::INT: {
+                switch (TYPEOF(mx)) {
+                    case LGLSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (LOGICAL(mx)[rowLength * i + j] != NA_LOGICAL) {
+                                element->set_intvalue((int32_t)LOGICAL(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case INTSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (INTEGER(mx)[rowLength * i + j] != NA_INTEGER) {
+                                element->set_intvalue(INTEGER(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case REALSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (REAL(mx)[rowLength * i + j] != NA_REAL) {
+                                element->set_intvalue((int32_t)REAL(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    default:
+                        this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                        subTypes[i]);
+                        break;
+                }
+            } break;
+            case plcontainer::PlcDataType::REAL: {
+                switch (TYPEOF(mx)) {
+                    case LGLSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (LOGICAL(mx)[rowLength * i + j] != NA_LOGICAL) {
+                                element->set_realvalue((double)LOGICAL(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case INTSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (INTEGER(mx)[rowLength * i + j] != NA_INTEGER) {
+                                element->set_realvalue((double)INTEGER(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    case REALSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (REAL(mx)[rowLength * i + j] != NA_REAL) {
+                                element->set_realvalue(REAL(mx)[rowLength * i + j]);
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    default:
+                        this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                        subTypes[i]);
+                        break;
+                }
+            } break;
+            case plcontainer::PlcDataType::TEXT: {
+                switch (TYPEOF(mx)) {
+                    case LGLSXP:
+                    case INTSXP:
+                    case REALSXP: {
+                        SEXP strobj;
+                        PROTECT(strobj = AS_CHARACTER(mx));
+                        for (int j = 0; j < rowLength; j++) {
+                            const char *value = CHAR(STRING_ELT(strobj, rowLength * i + j));
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (STRING_ELT(strobj, rowLength * i + j) != NA_STRING &&
+                                value != NULL) {
+                                element->set_stringvalue(std::string(value));
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                        UNPROTECT_PTR(strobj);
+                    } break;
+                    case RAWSXP:
+                    case STRSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            const char *value = CHAR(STRING_ELT(mx, rowLength * i + j));
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (STRING_ELT(mx, rowLength * i + j) != NA_STRING && value != NULL) {
+                                element->set_stringvalue(std::string(value));
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    default:
+                        this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                        subTypes[i]);
+                        break;
+                }
+            } break;
+            case plcontainer::PlcDataType::BYTEA: {
+                switch (TYPEOF(mx)) {
+                    case LGLSXP:
+                    case INTSXP:
+                    case REALSXP: {
+                        SEXP strobj;
+                        PROTECT(strobj = AS_CHARACTER(mx));
+                        for (int j = 0; j < rowLength; j++) {
+                            const char *value = CHAR(STRING_ELT(strobj, rowLength * i + j));
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (STRING_ELT(strobj, rowLength * i + j) != NA_STRING &&
+                                value != NULL) {
+                                element->set_byteavalue(std::string(value));
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                        UNPROTECT_PTR(strobj);
+                    } break;
+                    case RAWSXP:
+                    case STRSXP: {
+                        for (int j = 0; j < rowLength; j++) {
+                            const char *value = CHAR(STRING_ELT(mx, rowLength * i + j));
+                            plcontainer::ScalarData *element =
+                                result->mutable_rowvalues(j)->mutable_values(i);
+                            if (STRING_ELT(mx, rowLength * i + j) != NA_STRING && value != NULL) {
+                                element->set_byteavalue(std::string(value));
+                            } else {
+                                element->set_isnull(true);
+                            }
+                        }
+                    } break;
+                    default:
+                        this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d",
+                                        subTypes[i]);
+                        break;
+                }
+
+            } break;
+            default:
+                this->rLog->log(RServerLogLevel::ERRORS, "Unsupport type in value %d", subTypes[i]);
+                break;
+        }
+    }
+}
+
+void ConvertToProtoBuf::setofToProtoBuf(SEXP v, std::vector<plcontainer::PlcDataType> &subTypes,
+                                        plcontainer::SetOfData *result) {
+    if (isFrame(v) || isList(v) || isNewList(v)) {
+        // Both container factor
+        this->dataframeToSetof(v, subTypes, result);
+    } else if (isMatrix(v) || isVector(v)) {
+        // No factor
+        this->matrixToSetof(v, subTypes, result);
+    } else {
+        this->rLog->log(RServerLogLevel::ERRORS,
+                        "Unsupport R object when return type is setof/record");
+    }
 }

--- a/src/rutils.cc
+++ b/src/rutils.cc
@@ -36,11 +36,11 @@ void RServerLog::log(RServerLogLevel lvl, const char *format, ...) {
         this->printer->print(log);
     }
     switch (lvl) {
+        case RServerLogLevel::FATALS:
+            throw RServerFatalException(log);
+            break;
         case RServerLogLevel::ERRORS:
             throw RServerErrorException(log);
-            break;
-        case RServerLogLevel::WARNINGS:
-            throw RServerWarningException(log);
             break;
         default:
             break;

--- a/test/rcall_test.cc
+++ b/test/rcall_test.cc
@@ -106,7 +106,7 @@ TEST_F(RCallTest, RCoreEXECWithNoArgumentAndReturnHasArgument) {
     src->set_src("return (a)");
 
     EXPECT_EQ(ReturnStatus::OK, core->prepare(request));
-    EXPECT_THROW(core->execute(), RServerWarningException);
+    EXPECT_THROW(core->execute(), RServerErrorException);
 }
 
 TEST_F(RCallTest, RCoreGetResultsWithNoArgumentINT) {

--- a/test/rutils_test.cc
+++ b/test/rutils_test.cc
@@ -18,10 +18,10 @@ TEST(RUtilsTest, RLogInit) {
     log = new RServerLog(RServerWorkingMode::CONTAINERDEBUG, std::string("/tmp/rserver_log.log"));
 }
 
-TEST_F(RLogTest, RLogErrorException) {
-    EXPECT_THROW(log->log(RServerLogLevel::ERRORS, "test error"), RServerErrorException);
+TEST_F(RLogTest, RLogFatalException) {
+    EXPECT_THROW(log->log(RServerLogLevel::FATALS, "test error"), RServerFatalException);
 }
 
-TEST_F(RLogTest, RLogWarningException) {
-    EXPECT_THROW(log->log(RServerLogLevel::WARNINGS, "test warning"), RServerWarningException);
+TEST_F(RLogTest, RLogErrorException) {
+    EXPECT_THROW(log->log(RServerLogLevel::ERRORS, "test warning"), RServerErrorException);
 }


### PR DESCRIPTION
1. setof argument convert to data.frame
2. data.frame/list/vector/matrix can convert to setof as
   return value
3. list/matrix is considered as one row setof
4. code refactor with error message enhanced, add new log level fatal
   for unreoverable error
5. Unit test updated