### PR TITLE
Enhance RServer for concurrence query processing

### DIFF
--- a/include/rcall.hh
+++ b/include/rcall.hh
@@ -7,16 +7,16 @@
 #ifndef PLC_RCALL_H
 #define PLC_RCALL_H
 
-#include <iostream>
-#include <string>
 #include <exception>
-#include <vector>
+#include <iostream>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include "rutils.hh"
 
-#include "plcontainer.pb.h"
 #include "plcontainer.grpc.pb.h"
+#include "plcontainer.pb.h"
 
 #include "rtypeconverter.hh"
 
@@ -110,18 +110,21 @@ class RCoreRuntime : public PlcRuntime {
 
     void setLogger(RServerLog *log) { this->rLog = log; }
 
-    virtual ~RCoreRuntime() {};
+    void initRProtectList();
+    void releaseRProtectList();
+
+    virtual ~RCoreRuntime(){};
 
    protected:
     SEXP rCode;
     SEXP rArgument;
     SEXP rFunc;
     SEXP rResults;
+    SEXP rProtectList;
     PlcRuntimeType runType;
     PlcDataType returnType;
     std::vector<PlcDataType> returnSubType;
     RServerLog *rLog;
-    int32_t counter;
     // TODO: add cache for further requests
 
     void loadRCmd(const std::string &cmd);

--- a/include/rserver.hh
+++ b/include/rserver.hh
@@ -5,13 +5,13 @@
 
 #include <grpc/grpc.h>
 #include <grpc/status.h>
+#include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
-#include <grpcpp/security/server_credentials.h>
 
-#include "rutils.hh"
 #include "rcall.hh"
+#include "rutils.hh"
 
 #include "plcontainer.grpc.pb.h"
 #include "plcontainer.pb.h"
@@ -35,6 +35,7 @@ class RServerRPC final : public PLContainer::Service {
         this->runtime = nullptr;
         this->rLog = rLog;
         this->serverWorkingMode = mode;
+        // this->numberOfSession = 0; reserved for next step
     }
 
     virtual void initRCore();
@@ -57,6 +58,7 @@ class RServerRPC final : public PLContainer::Service {
     PlcRuntime *runtime;
     RServerLog *rLog;
     std::mutex mtx;
+    // int64_t numberOfSession; reserved for next step
     RServerWorkingMode serverWorkingMode;
 };
 
@@ -76,9 +78,7 @@ class RServer {
 
     void setLogger(RServerLog *log) { this->rLog = log; }
 
-    virtual ~RServer() {
-        delete server;
-    };
+    virtual ~RServer() { delete server; };
 
    private:
     RServerWorkingMode serverWorkingMode;

--- a/include/rutils.hh
+++ b/include/rutils.hh
@@ -1,12 +1,12 @@
 #ifndef _RUTILS_H
 #define _RUTILS_H
 
-#include <string>
-#include <cstdio>
 #include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <string>
 
 /* R header files */
 #include <R.h>
@@ -55,9 +55,7 @@ class RServerFatalException : public std::exception {
 
 class RServerErrorException : public std::exception {
    public:
-    RServerErrorException() {
-        this->msg = "R Server Runtime Warning ";
-    };
+    RServerErrorException() { this->msg = "R Server Runtime Warning "; };
     RServerErrorException(std::string &msg) { this->msg = "R Server Runtime Warning " + msg + " "; }
 
     virtual const char *what() const noexcept override { return this->msg.c_str(); }
@@ -69,7 +67,7 @@ class RServerErrorException : public std::exception {
 class LogPrinter {
    public:
     virtual void print(std::string &logs) = 0;
-    virtual ~LogPrinter() {};
+    virtual ~LogPrinter(){};
 };
 
 class FileLogPrinter : public LogPrinter {

--- a/src/rcall.cc
+++ b/src/rcall.cc
@@ -357,8 +357,8 @@ running in a container. I think -1 is equivalent to no limit.
     }
 
     if (status != PARSE_OK) {
-        this->rLog->log(RServerLogLevel::ERRORS,
-                        "Cannot parse user code: \n %s \n, error code is %d", code.c_str(), status);
+        // TODO: Update error message
+        this->rLog->log(RServerLogLevel::ERRORS, "Cannot parse user code %s", code.c_str());
         UNPROTECT(2);
         return ReturnStatus::OK;
     }

--- a/src/rtypeconverter.cc
+++ b/src/rtypeconverter.cc
@@ -890,7 +890,6 @@ void ConvertToProtoBuf::dataframeColumnStoreToRowStore(SEXP column, int32_t rowl
 
 void ConvertToProtoBuf::matrixToSetof(SEXP mx, std::vector<plcontainer::PlcDataType> &subTypes,
                                       plcontainer::SetOfData *result) {
-
     int columnLength = subTypes.size();
     int rowLength;
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -25,7 +25,6 @@ int main(int argc, char **argv) {
             server = new RServer(RServerWorkingMode::CONTAINER, log);
             server->initServer();
         } else {
-
             std::string mode = std::string(argv[1]);
 
             if (mode.compare("1") == 0) {
@@ -70,8 +69,7 @@ int main(int argc, char **argv) {
         }
 
         server->startServer();
-    }
-    catch (std::exception &e) {
+    } catch (std::exception &e) {
         if (log != nullptr) {
             log->log(RServerLogLevel::LOGS, "Unexpected R server runtime exception, exit now!");
         }

--- a/test/rcall_test.cc
+++ b/test/rcall_test.cc
@@ -10,6 +10,7 @@ class RCallTest : public testing::Test {
     virtual void SetUp() {
         logs = new RServerLog(RServerWorkingMode::CONTAINER, std::string(""));
         core = new RCoreRuntime(logs);
+        core->initRProtectList();
     }
 
     virtual void TearDown() {

--- a/test/rtypeconverter_test.cc
+++ b/test/rtypeconverter_test.cc
@@ -13,6 +13,7 @@ class RConvTest : public testing::Test {
     virtual void SetUp() {
         logs = new RServerLog(RServerWorkingMode::STANDALONG, std::string(""));
         core = new RCoreRuntime(logs);
+        core->initRProtectList();
     }
     virtual void TearDown() {
         delete core;


### PR DESCRIPTION
1. Protect R thread unsafe function by mtx
2. Enhance R object memeory protection
3. Release R object in more safe way[1]
4. Update Logs
5. Remove unused codes/logs
6. The minimum R version for RServer is updated to 3.5

Ref: [1] https://developer.r-project.org/Blog/public/2018/12/10/unprotecting-by-value/